### PR TITLE
Update eggNOG annotation from v5 to v7

### DIFF
--- a/data/annotate.sh
+++ b/data/annotate.sh
@@ -224,13 +224,18 @@ if notExists "${TMP_PATH}/tmp_join.tsv"; then
 	rm -f "${TMP_PATH}/PfamMappingFile"
 	rm -f "${TMP_PATH}/pfamA_desc.tsv"
 
-	echo "download eggNOG annotation file"
-	curl -o "${TMP_PATH}/nog_annotations.tsv" http://eggnog5.embl.de/download/eggnog_5.0/e5.og_annotations.tsv
+	echo "download eggNOG 7 protein families file"
+	curl -o "${TMP_PATH}/nog_families.tsv.gz" https://eggnogdb.org/public/eggnog7/e7.protein_families.tsv.gz && gunzip -f "${TMP_PATH}/nog_families.tsv.gz"
 
 	echo "obtain descriptions of the eggNOG orthology groups"
-	awk -F '\t' -v OFS='\t' 'BEGIN{OFS=FS="\t"} {print $2, $4}' "${TMP_PATH}/nog_annotations.tsv" >> "${TMP_PATH}/mappingFile" 
-	rm -f "${TMP_PATH}/nog_annotations.tsv" 
-	awk -F '\t' -v OFS='\t' 'BEGIN{OFS=FS="\t"} NR==FNR{clr[$1]=$2; next} { if ($5 in clr) {$5=clr[$5]; print}}' "${TMP_PATH}/mappingFile" "${TMP_PATH}/prof2_searchDB.tsv" | \
+	# Build OG → family name mapping from the protein families file.
+	# Column 7 lists all OGs per family (comma-separated), column 1 is the
+	# family name. Normalize pipe chars to hyphens so OG names match the
+	# profile DB headers (which use pipes in family names, e.g. 14|3|3
+	# instead of 14-3-3).
+	awk -F '\t' -v OFS='\t' '{n=split($7, ogs, ","); for(i=1;i<=n;i++) {key=ogs[i]; gsub(/\|/, "-", key); print key, $1}}' "${TMP_PATH}/nog_families.tsv" >> "${TMP_PATH}/mappingFile"
+	rm -f "${TMP_PATH}/nog_families.tsv"
+	awk -F '\t' -v OFS='\t' 'BEGIN{OFS=FS="\t"} NR==FNR{clr[$1]=$2; next} {key=$5; sub(/\.faa\.gz$/, "", key); gsub(/\|/, "-", key); if (key in clr) {$5=clr[key]; print}}' "${TMP_PATH}/mappingFile" "${TMP_PATH}/prof2_searchDB.tsv" | \
 	 LC_ALL=C sort -s -k1b,1 | awk -F '\t' -v OFS='\t' '{ $(NF+1) = "seq-prof search"; print}' | awk -F '\t' -v OFS='\t' '{ $(NF+1) = "eggNOG"; print}' >> "${TMP_PATH}/prof2_search_annot.tsv"
 
 	rm -f "${TMP_PATH}/prof2_searchDB.tsv"


### PR DESCRIPTION
## Summary

- Updates the eggNOG annotation from v5 to v7 in `data/annotate.sh`
- Downloads `e7.protein_families.tsv.gz` from `eggnogdb.org` instead of `e5.og_annotations.tsv` from `eggnog5.embl.de`
- Builds OG → family name mapping from the protein families file (column 7 OG list → column 1 family name)
- Normalizes pipe (`|`) vs hyphen (`-`) differences in OG family names between the eggNOG 7 profile DB headers and annotation files
- Strips `.faa.gz` suffix from profile DB headers before matching

## Motivation

The eggNOG 5.0 download endpoint (`eggnog5.embl.de`) is outdated and eggNOG 7 provides updated orthology assignments. The eggNOG 7 data files have a different format than eggNOG 5, requiring changes to the download, field extraction, and OG name matching in `data/annotate.sh`.

### Why `e7.protein_families.tsv.gz` instead of `e7.og_info_kegg_go.tsv.gz`

The protein families file (`e7.protein_families.tsv.gz`, 771 MB) provides a direct OG → family name mapping via its comma-separated OG list in column 7. This is simpler and ~150 MB smaller than `e7.og_info_kegg_go.tsv.gz` (922 MB).

### Key data format differences

| Aspect | eggNOG 5 | eggNOG 7 |
|--------|----------|----------|
| Download URL | `http://eggnog5.embl.de/.../e5.og_annotations.tsv` | `https://eggnogdb.org/.../e7.protein_families.tsv.gz` |
| Compression | Plain TSV | gzip compressed |
| Mapping | `$2` (OG name) → `$4` (description) | Split `$7` (OG list) → `$1` (family name) |
| OG name format in profile DB | Direct match | Pipes in family names (e.g. `14\|3\|3`) require normalization to hyphens (e.g. `14-3-3`) |
| Profile DB header suffix | None | `.faa.gz` appended to OG names |

## Test plan

- [x] Verified 1000/1000 sample eggNOG 7 profile DB headers match protein families file entries after normalization
- [x] Confirmed zero collisions: all 3,182,553 OG names remain unique after `|` → `-` normalization
- [x] Tested AWK join logic with mock data covering pipe-in-family-name cases (e.g. `14|3|3`), no-pipe cases (e.g. `2EXR`), and non-matching entries
- [x] Verified output format (10 TSV columns) is consistent with existing pipeline expectations